### PR TITLE
added author support

### DIFF
--- a/assets/css/easy-liveblogs.css
+++ b/assets/css/easy-liveblogs.css
@@ -86,12 +86,26 @@ ul.elb-liveblog-list {
 	font-size: 14px;
 }
 
+.elb-liveblog-post-author {
+	margin-top: 4px;
+	font-size: 18px;
+	font-weight: bold;
+}
+
 .elb-theme-light .elb-liveblog-post-time {
 	color: #666;
 }
 
+.elb-theme-light .elb-liveblog-post-author {
+	color: #111;
+}
+
 .elb-theme-dark .elb-liveblog-post-time {
 	color: #eee;
+}
+
+.elb-theme-dark .elb-liveblog-post-author {
+	color: #fff;
 }
 
 #elb-load-more {

--- a/includes/elb-post-types.php
+++ b/includes/elb-post-types.php
@@ -28,7 +28,7 @@ function elb_setup_post_types() {
 		'show_ui'         => true,
 		'capability_type' => 'post',
 		'map_meta_cap'    => true,
-		'supports'        => array( 'title', 'editor' ),
+		'supports'        => array( 'title','author', 'editor' ),
 		'can_export'      => true,
 		'menu_icon'       => 'dashicons-image-rotate'
 	);

--- a/templates/post.php
+++ b/templates/post.php
@@ -7,6 +7,7 @@ do_action( 'elb_before_liveblog_post', $post );
 ?>
 
 <p class="elb-liveblog-post-time"><time datetime="<?php echo get_the_time( 'Y-m-d H:i' ); ?>"><?php printf( _x( '%s ago', '%s = human-readable time difference', ELB_TEXT_DOMAIN ), human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) ) ); ?></time></p>
+<p class="elb-liveblog-post-author"><?php echo get_the_author(); ?></p>
 
 <h2 class="elb-liveblog-post-heading"><?php elb_entry_title(); ?></h2>
 


### PR DESCRIPTION
Added author support, can be very helpful when a liveblog is managed by multiple WordPress users and public needs to know who updated which entry.